### PR TITLE
feat: add timestamp_property_to_add input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # Intellij
 .idea/*
+
+# Mac
+**/.DS_Store

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,14 @@ inputs:
     description: |-
       The payload to be written into the referenced table in JSON format. It must reflect the schema of the table.
     required: true
+  timestamp_property_to_add:
+    descritpion: |-
+      If you want to add a timestamp property to the `payload_json` you can provide the name of the property with this input.
+      The schema of the `bigquery_table` must have a column of type `TIMESTAMP` and the name of this provided value.
+      The default is the empty string `''`. In this case the `payload_json` is not modified.
+      When it's not empty the according timestamp property is added to the `payload_json`.
+    required: false
+    default: ''
 
 runs:
   using: "composite"
@@ -42,6 +50,11 @@ runs:
         access_token_scopes: 'https://www.googleapis.com/auth/bigquery.insertdata'
         access_token_lifetime: "${{ inputs.token_lifetime }}"
 
+    - id: process
+      name: Process payload
+      shell: bash
+      run: ${{github.action_path}}/scripts/process-data.sh
+
     - id: write
       name: Write to BigQuery
       shell: bash
@@ -51,7 +64,7 @@ runs:
           --header 'Authorization: Bearer ${{ steps.auth.outputs.access_token }}' \
           --header 'Accept: application/json' \
           --header 'Content-Type: application/json' \
-          --data '{"rows":[{"json": ${{ inputs.payload_json }} }]}' \
+          --data '{"rows":[{"json": ${{env.payload_json}} }]}' \
           --compressed
 
 branding:

--- a/scripts/process-data.sh
+++ b/scripts/process-data.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Get the command-line arguments
+payload_json_original="$1"
+timestamp_property_to_add="$2"
+
+# Parse the JSON string into a shell variable
+payload_json=$(echo "$payload_json_original" | jq -c '.')
+
+# Add a timestamp property to the object if timestamp_property_to_add is not empty
+if [[ -n "$timestamp_property_to_add" ]]; then
+  timestamp_utc=$(date -u +%FT%T%Z)
+  payload_json=$(echo "$payload_json" | jq --arg timestamp_utc "$timestamp_utc" --arg timestamp_property "$timestamp_property_to_add" '. + {($timestamp_property): $timestamp_utc}')
+fi
+
+# Output the modified JSON string
+echo "processed payload:"
+echo "$payload_json"
+
+# Remove linebreaks from the modified JSON string
+payload_json=$(echo "$payload_json" | tr -d '\n')
+
+echo "$payload_json"
+echo "payload_json=$payload_json" >> $GITHUB_ENV


### PR DESCRIPTION
### Type of Change

<!-- Select the type of your PR -->

- [ ] Bugfix
- [x] Enhancement / new feature
- [ ] Refactoring
- [ ] Documentation

### Description

Adds the new input `timestamp_property_to_add` which can be used to add a timestamp property to the `payload_json`. With this input you can provide the name of the property to be added. The schema of the `bigquery_table` must have a column of type `TIMESTAMP` and the name of this provided input. The default is the empty string `''`. In this case the `payload_json` is not modified. When it's not empty the according timestamp property is added to the `payload_json`.

### Checklist

<!-- Please go through this checklist and make sure all applicable tasks have been done -->

- [ ] Write tests
- [ ] Make sure all tests pass
- [x] Update documentation
- [x] Review the [Contributing Guideline](../blob/master/CONTRIBUTING.md) and sign CLA
- [x] Reference relevant issue(s) and close them after merging
